### PR TITLE
Fix Copy Orders having incorrect links if nation name contains spaces

### DIFF
--- a/src/ts/mainpage.ts
+++ b/src/ts/mainpage.ts
@@ -730,7 +730,7 @@
         else if (delegateNation.indexOf('N/A') !== -1)
             return;
         copyText.value =
-            `@here **NOW**\nMove to: https://www.nationstates.net/region=${currentRegion.innerHTML}\nThen endorse: https://www.nationstates.net/nation=${delegateNation.replaceAll(" ", "_")}`;
+            `@here **NOW**\nMove to: https://www.nationstates.net/region=${currentRegion.innerHTML}\nThen endorse: https://www.nationstates.net/nation=${canonicalize(delegateNation)}`;
         document.body.appendChild(copyText);
         copyText.select();
         document.execCommand('copy');

--- a/src/ts/mainpage.ts
+++ b/src/ts/mainpage.ts
@@ -730,7 +730,7 @@
         else if (delegateNation.indexOf('N/A') !== -1)
             return;
         copyText.value =
-            `@here **NOW**\nMove to: https://www.nationstates.net/region=${currentRegion.innerHTML}\nThen endorse: https://www.nationstates.net/nation=${delegateNation}`;
+            `@here **NOW**\nMove to: https://www.nationstates.net/region=${currentRegion.innerHTML}\nThen endorse: https://www.nationstates.net/nation=${delegateNation.replaceAll(" ", "_")}`;
         document.body.appendChild(copyText);
         copyText.select();
         document.execCommand('copy');


### PR DESCRIPTION
the delegate link currently would be incorrectly cut off if a delegate nation contains spaces in their name.