### PR TITLE
Add custom image backgrounds to the main and prep page

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -12,6 +12,7 @@
   "permissions": [
     "activeTab",
     "storage",
+    "unlimitedStorage",
     "declarativeNetRequest",
     "declarativeNetRequestWithHostAccess"
   ],

--- a/src/ts/mainpage.ts
+++ b/src/ts/mainpage.ts
@@ -12,7 +12,7 @@
         <title>Reliant</title>
         <meta charset="utf-8">
     </head>
-    <body>
+    <body style="background-repeat: no-repeat; background-size: cover;">
         <div id="container">
             <div id="group-2">
                 <!-- Switchers -->
@@ -418,6 +418,13 @@
     document.open();
     document.write(pageContent);
     document.close();
+
+    chrome.storage.local.get('background', async (result) => {
+        if(result.background !== undefined) {
+            var body = (document.querySelector('body') as HTMLBodyElement);
+            body.style.backgroundImage = `url("${result.background}")`;
+        }
+    });
 
     await dieIfNoUserAgent();
 

--- a/src/ts/prep.ts
+++ b/src/ts/prep.ts
@@ -7,7 +7,7 @@
     <title>Reliant - Prep</title>
     <meta charset="utf-8">
 </head>
-<body>
+<body style="background-repeat: no-repeat; background-size: cover;">
 <div id="container">
     <div id="group-1">
         <div id="switchers-prepped-container">
@@ -38,6 +38,13 @@
     document.open();
     document.write(pageContent);
     document.close();
+
+    chrome.storage.local.get('background', async (result) => {
+        if(result.background !== undefined) {
+            var body = (document.querySelector('body') as HTMLBodyElement);
+            body.style.backgroundImage = `url("${result.background}")`;
+        }
+    });
 
     await dieIfNoUserAgent();
 

--- a/src/ts/settings.ts
+++ b/src/ts/settings.ts
@@ -74,6 +74,15 @@ a dossier button on the main page. Useful for chasing specific teams. <b>Leave b
 <input type="button" id="set-endorse-keywords" value="Set">
 </fieldset>
 <fieldset>
+<legend>Background Image</legend>
+<input type="file" id="new-background-image">
+<br/>
+<img id="uploaded-background-image" style="max-width:60%;"></img>
+<br/>
+<input class="button" type="button" id="set-background-image" value="Set">
+<input class="button" type="button" id="unset-background-image" value="Remove Background Image">
+</fieldset>
+<fieldset>
 <legend>Prepping</legend>
 <p><strong>Password</strong></p>
 <input type="password" id="my-password">
@@ -242,6 +251,9 @@ document.querySelector('#set-blocked-regions').addEventListener('click', setBloc
 document.querySelector('#set-dossier-keywords').addEventListener('click', setDossierKeywords);
 document.querySelector('#set-endorse-keywords').addEventListener('click', setEndorseKeywords);
 document.querySelector('#find-wa').addEventListener('click', findMyWa);
+document.querySelector('#set-background-image').addEventListener('click', setBackgroundImage);
+document.querySelector('#unset-background-image').addEventListener('click', unsetBackgroundImage);
+document.querySelector('#new-background-image').addEventListener('change', loadBackgroundImage);
 document.querySelector('#occupation-mode-toggle').addEventListener('change', toggleOccupationMode);
 
 /*
@@ -314,6 +326,46 @@ function setPassword(e: MouseEvent): void
     const password = (document.querySelector('#my-password') as HTMLInputElement).value;
     chrome.storage.local.set({'password': password});
     notyf.success(`Set password to ${password}`);
+}
+
+function loadBackgroundImage(e: Event): void
+{
+    var files = (e.target as HTMLInputElement).files;
+    
+    if (files && files.length) {
+        var reader = new FileReader();
+        reader.onload = function () {
+            (document.querySelector("#uploaded-background-image") as HTMLImageElement).src = 
+                reader.result as string;
+        }
+        reader.readAsDataURL(files[0]);
+    }
+}
+
+function setBackgroundImage(e: MouseEvent): void
+{
+    const image = (document.querySelector('#uploaded-background-image') as HTMLImageElement);
+
+    if(!image.complete || image.naturalWidth === 0)
+        throw new Error("Image isn't loaded yet");
+    
+    const canvas = document.createElement('canvas');
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error("Failed to get canvas context");
+
+    ctx.drawImage(image, 0, 0);
+
+    chrome.storage.local.set({'background': canvas.toDataURL('image/png')});
+    notyf.success(`Set new background image`);
+}
+
+function unsetBackgroundImage(e: MouseEvent): void
+{
+    chrome.storage.local.remove('background');
+    notyf.success('Cleared background image.');
 }
 
 function clearStoredWaApplications(e: MouseEvent): void


### PR DESCRIPTION
This pull request adds a section to the settings page for uploading a custom background image, which is saved into storage as a Base64 data:// image URL when the user presses "Set". This image, if it exists, is then loaded as the background for the main page and prep page.

If the user does not upload an image, or clicks the "Remove Background Image" button after setting one, the pages will remain as they did before.