### PR TITLE
Fix chk regex check

### DIFF
--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -184,7 +184,7 @@ function getChk(page?: string): void
     if (chk)
         chrome.storage.local.set({'chk': chk.value});
     else if (page) {
-        const chkRegex: RegExp = new RegExp('<input type="hidden" name="chk" value="([A-Za-z0-9]+?)">');
+        const chkRegex: RegExp = new RegExp('<input type="hidden" name="chk" value="([A-Za-z0-9_-]+?)">');
         const match: string[] = chkRegex.exec(page);
         chrome.storage.local.set({'chk': match[1]});
     }


### PR DESCRIPTION
It seems like the `<input type="hidden" name="chk">` field on the NationStates site can now include underscores and dashes in its value, which is causing Reliant's regex check for it to fail, making prep fail for most nations. This fix adds those characters to the regex pattern in question.